### PR TITLE
Change version to 1.0.0 for spring security related samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,6 +419,8 @@ terraform.rc
 
 
 # Property file used for local test.
+**/application-develop.properties
 **/application-develop.yml
+**/application-develop.yaml
 
 .history/

--- a/aad/spring-security/pom.xml
+++ b/aad/spring-security/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.spring</groupId>
   <artifactId>spring-boot-application-with-azure-active-directory</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/aad/spring-security/servlet/oauth2/client-access-multiple-resource-server/client/pom.xml
+++ b/aad/spring-security/servlet/oauth2/client-access-multiple-resource-server/client/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-client-access-multiple-resource-server-client-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/client-access-multiple-resource-server/resource-server-1/pom.xml
+++ b/aad/spring-security/servlet/oauth2/client-access-multiple-resource-server/resource-server-1/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-client-access-multiple-resource-server-resourc-server-1-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/client-access-multiple-resource-server/resource-server-2/pom.xml
+++ b/aad/spring-security/servlet/oauth2/client-access-multiple-resource-server/resource-server-2/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-client-access-multiple-resource-server-resourc-server-2-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/client-access-resource-server/client/pom.xml
+++ b/aad/spring-security/servlet/oauth2/client-access-resource-server/client/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-client-access-resource-server-client-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/client-access-resource-server/resource-server/pom.xml
+++ b/aad/spring-security/servlet/oauth2/client-access-resource-server/resource-server/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-client-access-resource-server-resource-server-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/login/pom.xml
+++ b/aad/spring-security/servlet/oauth2/login/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-login</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/resource-server-check-permissions-by-claims-in-access-token/client/pom.xml
+++ b/aad/spring-security/servlet/oauth2/resource-server-check-permissions-by-claims-in-access-token/client/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-resourc-server-check-permissions-by-claims-in-access-token-client-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/resource-server-check-permissions-by-claims-in-access-token/resource-server/pom.xml
+++ b/aad/spring-security/servlet/oauth2/resource-server-check-permissions-by-claims-in-access-token/resource-server/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-resourc-server-check-permissions-by-claims-in-access-token-resource-server-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/resource-server-support-on-behalf-of-flow/client/pom.xml
+++ b/aad/spring-security/servlet/oauth2/resource-server-support-on-behalf-of-flow/client/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-resourc-server-support-on-behalf-of-flow-client-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/resource-server-support-on-behalf-of-flow/resource-server-1/pom.xml
+++ b/aad/spring-security/servlet/oauth2/resource-server-support-on-behalf-of-flow/resource-server-1/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-resourc-server-support-on-behalf-of-flow-resource-server-1-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/aad/spring-security/servlet/oauth2/resource-server-support-on-behalf-of-flow/resource-server-2/pom.xml
+++ b/aad/spring-security/servlet/oauth2/resource-server-support-on-behalf-of-flow/resource-server-2/pom.xml
@@ -11,9 +11,8 @@
     <relativePath>../../../../../../pom.xml</relativePath>
   </parent>
 
-  <groupId>com.azure.spring</groupId>
   <artifactId>servlet-oauth2-resourc-server-support-on-behalf-of-flow-resource-server-2-application</artifactId>
-  <version>2.5.6-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
 
   <dependencies>


### PR DESCRIPTION
1. Change version to 1.0.0 for all spring-security related sample.
2. Delete redundant groupId.
3. Update .gitignore.