### PR TITLE
Use GitHub action to sync label between azure-sdk-for-java repo and this repo

### DIFF
--- a/.github/workflows/sync-label-from-azsdk-repo.yml
+++ b/.github/workflows/sync-label-from-azsdk-repo.yml
@@ -1,0 +1,16 @@
+name: Sync Labels
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Labels
+        run:  curl https://api.github.com/repos/Azure/azure-sdk-for-java/labels\?per_page\=1000 | jq -c '.[] | select(.name | contains("spring"))' | jq -s >> labels.json
+
+      - name: Label Sync
+        uses: EndBug/label-sync@v2.1.0
+        with:
+          config-file: ./labels.json
+          dry-run: false


### PR DESCRIPTION
As the title to add a GitHub action to sync all spring labels from [azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java/labels?q=spring) repo. 

See https://github.com/Azure/azure-sdk-for-java/issues/28019 also.