### PR TITLE
Update markdown link check workflow with v1.0.13 tag

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@8f0156cc69c9f6dfaad8aae63f93a7a604b95b5f
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
       with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@v1.0.13
+    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.13
       with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'


### PR DESCRIPTION
## Description
Reverted github-action-markdown-link-check action in the check-links workflow to version 1.0.13 due to https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/127
