### PR TITLE
Update ci workflow to add folder `sdk/aot`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           echo "eng" >> .git/info/sparse-checkout
           echo "sdk/keyvault" >> .git/info/sparse-checkout
           echo "sdk/boms" >> .git/info/sparse-checkout
+          echo "sdk/aot" >> .git/info/sparse-checkout
           git pull --depth=1 origin main
           mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
             -Dcheckstyle.skip=true \

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -47,6 +47,7 @@ jobs:
           echo "eng" >> .git/info/sparse-checkout
           echo "sdk/keyvault" >> .git/info/sparse-checkout
           echo "sdk/boms" >> .git/info/sparse-checkout
+          echo "sdk/aot" >> .git/info/sparse-checkout
           git pull --depth=1 origin main
           mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
             -Dcheckstyle.skip=true \


### PR DESCRIPTION
In this PR:https://github.com/Azure-Samples/azure-spring-boot-samples/pull/283, libraries under folder `sdk/aot` are imported, so we need to add the folder in ci workflow configuration file.


---
Linked with https://github.com/Azure/azure-sdk-for-java/pull/28500/