### PR TITLE
Manually upgrade spring-boot-starter-parent to 2.6.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.6.7</version>
   </parent>
 
   <groupId>com.azure.spring</groupId>


### PR DESCRIPTION
As title.
Refer to https://github.com/Azure-Samples/azure-spring-boot-samples/pull/274.
Try to awake dependabot. 