### PR TITLE
Fix data.azurerm_client_config.current.object_id return "" empty when upgrading az cli to 2.37.0

### DIFF
--- a/appconfiguration/spring-cloud-azure-starter-appconfiguration/appconfiguration-client/terraform/main.tf
+++ b/appconfiguration/spring-cloud-azure-starter-appconfiguration/appconfiguration-client/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/cache/spring-cloud-azure-starter/spring-cloud-azure-sample-cache/terraform/main.tf
+++ b/cache/spring-cloud-azure-starter/spring-cloud-azure-sample-cache/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account/terraform/main.tf
+++ b/cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm  = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/cosmos/azure-spring-data-cosmos/cosmos-multi-database-single-account/terraform/main.tf
+++ b/cosmos/azure-spring-data-cosmos/cosmos-multi-database-single-account/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm  = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/cosmos/spring-cloud-azure-starter-cosmos/spring-cloud-azure-cosmos-sample/terraform/main.tf
+++ b/cosmos/spring-cloud-azure-starter-cosmos/spring-cloud-azure-cosmos-sample/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/cosmos/spring-cloud-azure-starter-data-cosmos/spring-cloud-azure-data-cosmos-sample/terraform/main.tf
+++ b/cosmos/spring-cloud-azure-starter-data-cosmos/spring-cloud-azure-data-cosmos-sample/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/eventhubs/spring-cloud-azure-starter-eventhubs/eventhubs-client/terraform/main.tf
+++ b/eventhubs/spring-cloud-azure-starter-eventhubs/eventhubs-client/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/eventhubs/spring-cloud-azure-starter-integration-eventhubs/eventhubs-integration/terraform/main.tf
+++ b/eventhubs/spring-cloud-azure-starter-integration-eventhubs/eventhubs-integration/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka/terraform/main.tf
+++ b/eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-binder/terraform/main.tf
+++ b/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-binder/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders/terraform/main.tf
+++ b/eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source/terraform/main.tf
+++ b/keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/keyvault/spring-cloud-azure-starter-keyvault-secrets/secret-client/terraform/main.tf
+++ b/keyvault/spring-cloud-azure-starter-keyvault-secrets/secret-client/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-starter-integration-servicebus/multiple-namespaces/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-starter-integration-servicebus/multiple-namespaces/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-starter-integration-servicebus/single-namespace/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-starter-integration-servicebus/single-namespace/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-topic/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-topic/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-stream-binder-servicebus/servicebus-multibinders/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-stream-binder-servicebus/servicebus-multibinders/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-stream-binder-servicebus/servicebus-queue-binder/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-stream-binder-servicebus/servicebus-queue-binder/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/servicebus/spring-cloud-azure-stream-binder-servicebus/servicebus-topic-binder/terraform/main.tf
+++ b/servicebus/spring-cloud-azure-stream-binder-servicebus/servicebus-topic-binder/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/spring-native/storage-blob-native/terraform/main.tf
+++ b/spring-native/storage-blob-native/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/spring-petclinic-microservices/terraform/main.tf
+++ b/spring-petclinic-microservices/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm  = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-integration/terraform/main.tf
+++ b/storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-integration/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-operation/terraform/main.tf
+++ b/storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-operation/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/storage/spring-cloud-azure-starter-storage-blob/storage-blob-sample/terraform/main.tf
+++ b/storage/spring-cloud-azure-starter-storage-blob/storage-blob-sample/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"

--- a/storage/spring-cloud-azure-starter-storage-queue/storage-queue-client/terraform/main.tf
+++ b/storage/spring-cloud-azure-starter-storage-queue/storage-queue-client/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.99"
+      version = "3.9.0"
     }
     azurecaf = {
       source  = "aztfmod/azurecaf"


### PR DESCRIPTION
Context

When running samples with terraform, the same issue happens as the https://github.com/hashicorp/terraform-provider-azurerm/issues/16982 described.

Solution
Upgrade version of hashicorp/azurerm to 3.9.0.


Checklist:
- [ ] Test all samples with terraform.
