### PR TITLE
Fix Running terraform script will return ipv6 address instead of ipv4 address

### DIFF
--- a/cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account/terraform/main.tf
+++ b/cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account/terraform/main.tf
@@ -8,11 +8,18 @@ terraform {
       source  = "aztfmod/azurecaf"
       version = "1.2.16"
     }
+    publicip = {
+      source = "nxt-engineering/publicip"
+      version = "0.0.7"
+    }
   }
 }
 
 provider "azurerm" {
   features {}
+}
+
+provider "publicip" {
 }
 
 resource "azurecaf_name" "resource_group" {
@@ -145,7 +152,8 @@ resource "azurerm_mysql_server" "mysql" {
   geo_redundant_backup_enabled      = true
   infrastructure_encryption_enabled = true
   public_network_access_enabled     = true
-  ssl_enforcement_enabled           = false
+  ssl_enforcement_enabled           = true
+  ssl_minimal_tls_version_enforced  = "TLS1_2"
 }
 
 resource "azurerm_mysql_database" "database" {
@@ -156,21 +164,15 @@ resource "azurerm_mysql_database" "database" {
   collation           = "utf8_unicode_ci"
 }
 
-data "http" "my_public_ip" {
-  url = "https://ifconfig.co/json"
-  request_headers = {
-    Accept = "application/json"
-  }
-}
 
-locals {
-  ifconfig_co_json = jsondecode(data.http.my_public_ip.body)
+data "publicip_address" "default_v4" {
+  source_ip = "0.0.0.0"
 }
 
 resource "azurerm_mysql_firewall_rule" "client_ip" {
   name                = "allowip"
   resource_group_name = azurerm_resource_group.main.name
   server_name         = azurerm_mysql_server.mysql.name
-  start_ip_address    = local.ifconfig_co_json.ip
-  end_ip_address      = local.ifconfig_co_json.ip
+  start_ip_address    = data.publicip_address.default_v4.ip
+  end_ip_address      = data.publicip_address.default_v4.ip
 }


### PR DESCRIPTION
By default, the terraform script of this [sample](https://github.com/Azure-Samples/azure-spring-boot-samples/tree/ca097dbb929c202903aa344f8bdcea51d7b7f0a8/cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account) will resolve with ipv6 address, while the expected value is ipv4 address, this PR is used to address this issue.
