### PR TITLE
Update samples to use Spring Cloud Azure 6.0.0-beta.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           cd azure-sdk-for-java
           git remote add origin https://github.com/Azure/azure-sdk-for-java.git
           git config core.sparsecheckout true
+          echo "sdk/parents/azure-client-sdk-parent" >> .git/info/sparse-checkout
           echo "sdk/spring" >> .git/info/sparse-checkout
           echo "sdk/spring-experimental" >> .git/info/sparse-checkout
           echo "eng" >> .git/info/sparse-checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           echo "sdk/spring-experimental" >> .git/info/sparse-checkout
           echo "eng" >> .git/info/sparse-checkout
           echo "sdk/boms" >> .git/info/sparse-checkout
-          git pull --depth=1 origin main
+          git pull --depth=1 origin feature/spring-cloud-azure-6.x
           mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
             -Dcheckstyle.skip=true \
             -ntp \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,21 @@ jobs:
             -Dparallel-test-playback \
             -Pdev \
             -f sdk/spring-experimental/pom.xml
+          mvn clean install -Dmaven.javadoc.skip=true -DskipTests \
+            -Dcheckstyle.skip=true \
+            -ntp \
+            -Dspotbugs.skip=true \
+            -Drevapi.skip=true -Djacoco.skip=true \
+            -Dparallel-test-playback \
+            -Pdev \
+            -f sdk/boms/pom.xml
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
       run: mvn -f pom.xml --batch-mode --update-snapshots verify
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        java-version: '8'
-        distribution: 'adopt'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -f pom.xml --batch-mode --update-snapshots verify
+

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,6 +43,7 @@ jobs:
           cd azure-sdk-for-java
           git remote add origin https://github.com/Azure/azure-sdk-for-java.git
           git config core.sparsecheckout true
+          echo "sdk/parents/azure-client-sdk-parent" >> .git/info/sparse-checkout
           echo "sdk/spring" >> .git/info/sparse-checkout
           echo "sdk/spring-experimental" >> .git/info/sparse-checkout
           echo "eng" >> .git/info/sparse-checkout

--- a/aad/spring-cloud-azure-starter-active-directory/aad-web-application-and-resource-server/src/main/java/com/azure/spring/sample/aad/security/AadConditionalAccessFilter.java
+++ b/aad/spring-cloud-azure-starter-active-directory/aad-web-application-and-resource-server/src/main/java/com/azure/spring/sample/aad/security/AadConditionalAccessFilter.java
@@ -4,16 +4,16 @@
 package com.azure.spring.sample.aad.security;
 
 import com.azure.spring.cloud.autoconfigure.aad.AadClientRegistrationRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.client.ClientAuthorizationRequiredException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;

--- a/aad/spring-cloud-azure-starter-active-directory/aad-web-application-and-resource-server/src/main/java/com/azure/spring/sample/aad/security/AadWebApplicationAndResourceServerConfig.java
+++ b/aad/spring-cloud-azure-starter-active-directory/aad-web-application-and-resource-server/src/main/java/com/azure/spring/sample/aad/security/AadWebApplicationAndResourceServerConfig.java
@@ -5,13 +5,12 @@ package com.azure.spring.sample.aad.security;
 
 import com.azure.spring.cloud.autoconfigure.aad.AadResourceServerWebSecurityConfigurerAdapter;
 import com.azure.spring.cloud.autoconfigure.aad.AadWebSecurityConfigurerAdapter;
+import jakarta.servlet.Filter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
-import javax.servlet.Filter;
 
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)

--- a/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-resource-server-obo/src/main/java/com/azure/spring/sample/aad/controller/SampleController.java
+++ b/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-resource-server-obo/src/main/java/com/azure/spring/sample/aad/controller/SampleController.java
@@ -3,6 +3,8 @@
 
 package com.azure.spring.sample.aad.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,8 +21,6 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import static org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction.oauth2AuthorizedClient;
 

--- a/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-web-application/src/main/java/com/azure/spring/sample/aad/security/AadConditionalAccessFilter.java
+++ b/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-web-application/src/main/java/com/azure/spring/sample/aad/security/AadConditionalAccessFilter.java
@@ -4,16 +4,16 @@
 package com.azure.spring.sample.aad.security;
 
 import com.azure.spring.cloud.autoconfigure.aad.AadClientRegistrationRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.client.ClientAuthorizationRequiredException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;

--- a/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-web-application/src/main/java/com/azure/spring/sample/aad/security/AadWebApplicationConfig.java
+++ b/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-web-application/src/main/java/com/azure/spring/sample/aad/security/AadWebApplicationConfig.java
@@ -4,12 +4,12 @@
 package com.azure.spring.sample.aad.security;
 
 import com.azure.spring.cloud.autoconfigure.aad.AadWebSecurityConfigurerAdapter;
+import jakarta.servlet.Filter;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
-import javax.servlet.Filter;
 
 @Profile("conditional-access")
 @EnableWebSecurity

--- a/aad/spring-security/servlet/oauth2/login-authenticate-using-private-key-jwt/src/test/java/com/azure/spring/sample/reactive/servlet/oauth2/login/jwt/azure/activedirectory/AzureActiveDirectoryCertificateSignedAssertionFactoryTest.java
+++ b/aad/spring-security/servlet/oauth2/login-authenticate-using-private-key-jwt/src/test/java/com/azure/spring/sample/reactive/servlet/oauth2/login/jwt/azure/activedirectory/AzureActiveDirectoryCertificateSignedAssertionFactoryTest.java
@@ -2,10 +2,10 @@ package com.azure.spring.sample.reactive.servlet.oauth2.login.jwt.azure.activedi
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.xml.bind.DatatypeConverter;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,14 @@
 
   <properties>
     <java.version>17</java.version>
-    <version.guava>31.1-jre</version.guava>
     <version.spring.cloud>2022.0.0-M4</version.spring.cloud>
     <version.spring.cloud.azure>6.0.0-beta.1</version.spring.cloud.azure>
-    <!--<version.spring-cloud-appconfiguration-config>2.8.0</version.spring-cloud-appconfiguration-config>
+    <version.thymeleaf-extras-springsecurity5>3.1.0.M1</version.thymeleaf-extras-springsecurity5>
+    <!--<version.guava>31.1-jre</version.guava>
+    <version.spring-cloud-appconfiguration-config>2.8.0</version.spring-cloud-appconfiguration-config>
     <version.spring-cloud-appconfiguration-starter>2.8.0</version.spring-cloud-appconfiguration-starter>
     <version.spring-cloud-feature-management>2.7.0</version.spring-cloud-feature-management>
     <version.azure-spring-boot-starter-keyvault-certificates>3.14.0</version.azure-spring-boot-starter-keyvault-certificates>-->
-    <version.thymeleaf-extras-springsecurity5>3.1.0.M1</version.thymeleaf-extras-springsecurity5>
   </properties>
   <modules>
     <module>aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server</module>
@@ -54,10 +54,10 @@
     <module>eventhubs/spring-cloud-azure-starter-eventhubs/eventhubs-client</module>
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-binder</module>
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders</module>
-    <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-server-side</module>
-    <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-client-side</module>
-    <!--<module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side</module>
-    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>-->
+    <!--<module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-server-side</module>
+    <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-client-side</module>-->
+    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side</module>
+    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source</module>
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/secret-client</module>
     <module>servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue</module>
@@ -112,13 +112,13 @@
         <groupId>com.azure.spring</groupId>
         <artifactId>azure-spring-cloud-feature-management-web</artifactId>
         <version>${version.spring-cloud-feature-management}</version>
-      </dependency>-->
+      </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${version.guava}</version>
       </dependency>
-      <!--<dependency>
+      <dependency>
         <groupId>com.azure.spring</groupId>
         <artifactId>azure-spring-boot-starter-keyvault-certificates</artifactId>
         <version>${version.azure-spring-boot-starter-keyvault-certificates}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,6 @@
     <version.spring.cloud>2022.0.0-M4</version.spring.cloud>
     <version.spring.cloud.azure>6.0.0-beta.1</version.spring.cloud.azure>
     <version.thymeleaf-extras-springsecurity5>3.1.0.M1</version.thymeleaf-extras-springsecurity5>
-    <!--<version.guava>31.1-jre</version.guava>
-    <version.spring-cloud-appconfiguration-config>2.8.0</version.spring-cloud-appconfiguration-config>
-    <version.spring-cloud-appconfiguration-starter>2.8.0</version.spring-cloud-appconfiguration-starter>
-    <version.spring-cloud-feature-management>2.7.0</version.spring-cloud-feature-management>
-    <version.azure-spring-boot-starter-keyvault-certificates>3.14.0</version.azure-spring-boot-starter-keyvault-certificates>-->
   </properties>
   <modules>
     <module>aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server</module>
@@ -36,28 +31,14 @@
     <module>aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-web-application</module>
     <module>aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-resource-server</module>
     <module>aad/spring-security</module>
-    <!--<module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-complete</module>
-    <module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-initial</module>
-    <module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-sample</module>
-    <module>appconfiguration/azure-spring-cloud-feature-management-web/azure-spring-cloud-feature-management-web-sample</module>
-    <module>appconfiguration/azure-spring-cloud-feature-management/azure-spring-cloud-feature-management-sample</module>
-    <module>appconfiguration/azure-spring-cloud-starter-appconfiguration-config/azure-spring-cloud-starter-appconfiguration-config-sample</module>-->
     <module>appconfiguration/spring-cloud-azure-starter-appconfiguration/appconfiguration-client</module>
     <module>cache/spring-cloud-azure-starter/spring-cloud-azure-sample-cache</module>
-    <!--<module>cloudfoundry/azure-cloud-foundry-service-sample</module>
-    <module>cosmos/spring-cloud-azure-starter-data-cosmos/spring-cloud-azure-data-cosmos-sample</module>-->
     <module>cosmos/spring-cloud-azure-starter-cosmos/spring-cloud-azure-cosmos-sample</module>
-    <!--<module>cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account</module>
-    <module>cosmos/azure-spring-data-cosmos/cosmos-multi-database-single-account</module>-->
     <module>eventhubs/spring-cloud-azure-starter-integration-eventhubs/eventhubs-integration</module>
     <module>eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka</module>
     <module>eventhubs/spring-cloud-azure-starter-eventhubs/eventhubs-client</module>
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-binder</module>
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders</module>
-    <!--<module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-server-side</module>
-    <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-client-side</module>
-    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side</module>
-    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>-->
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source</module>
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/secret-client</module>
     <module>servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue</module>
@@ -73,8 +54,6 @@
     <module>storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-operation</module>
     <module>storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-integration</module>
     <module>storage/spring-cloud-azure-starter-storage-queue/storage-queue-client</module>
-    <!--<module>spring-native/storage-blob-native</module>
-    <module>spring-petclinic-microservices</module>-->
   </modules>
 
   <dependencyManagement>
@@ -93,36 +72,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!--<dependency>
-        <groupId>com.azure.spring</groupId>
-        <artifactId>azure-spring-cloud-appconfiguration-config</artifactId>
-        <version>${version.spring-cloud-appconfiguration-config}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.azure.spring</groupId>
-        <artifactId>azure-spring-cloud-starter-appconfiguration-config</artifactId>
-        <version>${version.spring-cloud-appconfiguration-starter}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.azure.spring</groupId>
-        <artifactId>azure-spring-cloud-feature-management</artifactId>
-        <version>${version.spring-cloud-feature-management}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.azure.spring</groupId>
-        <artifactId>azure-spring-cloud-feature-management-web</artifactId>
-        <version>${version.spring-cloud-feature-management}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${version.guava}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.azure.spring</groupId>
-        <artifactId>azure-spring-boot-starter-keyvault-certificates</artifactId>
-        <version>${version.azure-spring-boot-starter-keyvault-certificates}</version>
-      </dependency>-->
       <dependency>
         <groupId>org.thymeleaf.extras</groupId>
         <artifactId>thymeleaf-extras-springsecurity5</artifactId>
@@ -297,159 +246,6 @@
         </dependencies>
       </dependencyManagement>
     </profile>
-    <!--<profile>
-      <id>buildpack</id>
-      <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <repackage.classifier>exec</repackage.classifier>
-        <spring-native.version>0.12.0</spring-native.version>
-        <spring-cloud-azure-native-configuration.version>4.0.0-beta.1</spring-cloud-azure-native-configuration.version>
-      </properties>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.springframework.experimental</groupId>
-          <artifactId>spring-native</artifactId>
-          <version>${spring-native.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.azure.spring</groupId>
-          <artifactId>spring-cloud-azure-native-configuration</artifactId>
-          <version>${spring-cloud-azure-native-configuration.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.junit.platform</groupId>
-          <artifactId>junit-platform-launcher</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <build>
-        <finalName>${project.artifactId}</finalName>
-        <plugins>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <configuration>
-              <classifier>${repackage.classifier}</classifier>
-              <image>
-                <builder>paketobuildpacks/builder:tiny</builder>
-                <env>
-                  <BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>
-                </env>
-              </image>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.springframework.experimental</groupId>
-            <artifactId>spring-aot-maven-plugin</artifactId>
-            <version>${spring-native.version}</version>
-            <executions>
-              <execution>
-                <id>generate</id>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>test-generate</id>
-                <goals>
-                  <goal>test-generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>native</id>
-      <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <repackage.classifier>exec</repackage.classifier>
-        <imageName>${artifactId}</imageName>
-        <native.maven.plugin.version>0.9.11</native.maven.plugin.version>
-        <spring-native.version>0.11.4</spring-native.version>
-        <spring-cloud-azure-native-configuration.version>4.0.0-beta.1</spring-cloud-azure-native-configuration.version>
-      </properties>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.springframework.experimental</groupId>
-          <artifactId>spring-native</artifactId>
-          <version>${spring-native.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>com.azure.spring</groupId>
-          <artifactId>spring-cloud-azure-native-configuration</artifactId>
-          <version>${spring-cloud-azure-native-configuration.version}</version>
-        </dependency>
-        <dependency>
-          <groupId>org.junit.platform</groupId>
-          <artifactId>junit-platform-launcher</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <configuration>
-              <classifier>${repackage.classifier}</classifier>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.springframework.experimental</groupId>
-            <artifactId>spring-aot-maven-plugin</artifactId>
-            <version>${spring-native.version}</version>
-            <executions>
-              <execution>
-                <id>generate</id>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>test-generate</id>
-                <goals>
-                  <goal>test-generate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-            <version>${native.maven.plugin.version}</version>
-            <extensions>true</extensions>
-            <executions>
-              <execution>
-                <id>test-native</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>build-native</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <imageName>${imageName}</imageName>
-              <buildArgs>
-                <buildArg>-H:+ReportExceptionStackTraces</buildArg>
-              </buildArgs>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>-->
   </profiles>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.2</version>
+    <version>3.0.0-M4</version>
   </parent>
 
   <groupId>com.azure.spring</groupId>
@@ -18,15 +18,15 @@
   <name>Azure Spring Boot Samples</name>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <java.version>17</java.version>
     <version.guava>31.1-jre</version.guava>
-    <version.spring.cloud>2021.0.3</version.spring.cloud>
-    <version.spring.cloud.azure>4.3.0</version.spring.cloud.azure>
-    <version.spring-cloud-appconfiguration-config>2.8.0</version.spring-cloud-appconfiguration-config>
+    <version.spring.cloud>2022.0.0-M4</version.spring.cloud>
+    <version.spring.cloud.azure>6.0.0-beta.1</version.spring.cloud.azure>
+    <!--<version.spring-cloud-appconfiguration-config>2.8.0</version.spring-cloud-appconfiguration-config>
     <version.spring-cloud-appconfiguration-starter>2.8.0</version.spring-cloud-appconfiguration-starter>
     <version.spring-cloud-feature-management>2.7.0</version.spring-cloud-feature-management>
-    <version.azure-spring-boot-starter-keyvault-certificates>3.14.0</version.azure-spring-boot-starter-keyvault-certificates>
+    <version.azure-spring-boot-starter-keyvault-certificates>3.14.0</version.azure-spring-boot-starter-keyvault-certificates>-->
+    <version.thymeleaf-extras-springsecurity5>3.1.0.M1</version.thymeleaf-extras-springsecurity5>
   </properties>
   <modules>
     <module>aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server</module>
@@ -36,19 +36,19 @@
     <module>aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-web-application</module>
     <module>aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-resource-server</module>
     <module>aad/spring-security</module>
-    <module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-complete</module>
+    <!--<module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-complete</module>
     <module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-initial</module>
     <module>appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-sample</module>
     <module>appconfiguration/azure-spring-cloud-feature-management-web/azure-spring-cloud-feature-management-web-sample</module>
     <module>appconfiguration/azure-spring-cloud-feature-management/azure-spring-cloud-feature-management-sample</module>
-    <module>appconfiguration/azure-spring-cloud-starter-appconfiguration-config/azure-spring-cloud-starter-appconfiguration-config-sample</module>
+    <module>appconfiguration/azure-spring-cloud-starter-appconfiguration-config/azure-spring-cloud-starter-appconfiguration-config-sample</module>-->
     <module>appconfiguration/spring-cloud-azure-starter-appconfiguration/appconfiguration-client</module>
     <module>cache/spring-cloud-azure-starter/spring-cloud-azure-sample-cache</module>
-    <module>cloudfoundry/azure-cloud-foundry-service-sample</module>
-    <module>cosmos/spring-cloud-azure-starter-data-cosmos/spring-cloud-azure-data-cosmos-sample</module>
+    <!--<module>cloudfoundry/azure-cloud-foundry-service-sample</module>
+    <module>cosmos/spring-cloud-azure-starter-data-cosmos/spring-cloud-azure-data-cosmos-sample</module>-->
     <module>cosmos/spring-cloud-azure-starter-cosmos/spring-cloud-azure-cosmos-sample</module>
-    <module>cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account</module>
-    <module>cosmos/azure-spring-data-cosmos/cosmos-multi-database-single-account</module>
+    <!--<module>cosmos/azure-spring-data-cosmos/cosmos-multi-database-multi-account</module>
+    <module>cosmos/azure-spring-data-cosmos/cosmos-multi-database-single-account</module>-->
     <module>eventhubs/spring-cloud-azure-starter-integration-eventhubs/eventhubs-integration</module>
     <module>eventhubs/spring-cloud-azure-starter/spring-cloud-azure-sample-eventhubs-kafka</module>
     <module>eventhubs/spring-cloud-azure-starter-eventhubs/eventhubs-client</module>
@@ -56,8 +56,8 @@
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders</module>
     <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-server-side</module>
     <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-client-side</module>
-    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side</module>
-    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>
+    <!--<module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side</module>
+    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>-->
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source</module>
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/secret-client</module>
     <module>servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue</module>
@@ -73,8 +73,8 @@
     <module>storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-operation</module>
     <module>storage/spring-cloud-azure-starter-integration-storage-queue/storage-queue-integration</module>
     <module>storage/spring-cloud-azure-starter-storage-queue/storage-queue-client</module>
-    <module>spring-native/storage-blob-native</module>
-    <module>spring-petclinic-microservices</module>
+    <!--<module>spring-native/storage-blob-native</module>
+    <module>spring-petclinic-microservices</module>-->
   </modules>
 
   <dependencyManagement>
@@ -93,7 +93,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
+      <!--<dependency>
         <groupId>com.azure.spring</groupId>
         <artifactId>azure-spring-cloud-appconfiguration-config</artifactId>
         <version>${version.spring-cloud-appconfiguration-config}</version>
@@ -112,16 +112,21 @@
         <groupId>com.azure.spring</groupId>
         <artifactId>azure-spring-cloud-feature-management-web</artifactId>
         <version>${version.spring-cloud-feature-management}</version>
-      </dependency>
+      </dependency>-->
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${version.guava}</version>
       </dependency>
-      <dependency>
+      <!--<dependency>
         <groupId>com.azure.spring</groupId>
         <artifactId>azure-spring-boot-starter-keyvault-certificates</artifactId>
         <version>${version.azure-spring-boot-starter-keyvault-certificates}</version>
+      </dependency>-->
+      <dependency>
+        <groupId>org.thymeleaf.extras</groupId>
+        <artifactId>thymeleaf-extras-springsecurity5</artifactId>
+        <version>${version.thymeleaf-extras-springsecurity5}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -292,7 +297,7 @@
         </dependencies>
       </dependencyManagement>
     </profile>
-    <profile>
+    <!--<profile>
       <id>buildpack</id>
       <properties>
         <maven.compiler.source>11</maven.compiler.source>
@@ -444,7 +449,7 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
+    </profile>-->
   </profiles>
 
   <repositories>
@@ -456,6 +461,14 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -463,6 +476,14 @@
       <id>spring-release</id>
       <name>Spring release</name>
       <url>https://repo.spring.io/release</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
+    <pluginRepository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-binder</module>
     <module>eventhubs/spring-cloud-azure-stream-binder-eventhubs/eventhubs-multibinders</module>
     <!--<module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-server-side</module>
-    <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-client-side</module>-->
+    <module>keyvault/azure-securtiy-keyvault-jca/run-with-command-line-client-side</module>
     <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side</module>
-    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>
+    <module>keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side</module>-->
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/property-source</module>
     <module>keyvault/spring-cloud-azure-starter-keyvault-secrets/secret-client</module>
     <module>servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue</module>

--- a/spring-petclinic-microservices/pom.xml
+++ b/spring-petclinic-microservices/pom.xml
@@ -75,28 +75,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <profiles>
     <profile>
       <id>springboot</id>


### PR DESCRIPTION
This PR is to support the Spring Cloud Azure 6.0.0-beta.1 based on Spring Boot 3.0.0-M4.
Exclude some samples because the below reasons:
- storage-blob-native
   Spring Native is not supported since Spring Boot 3
- spring-petclinic-microservices
   Need to refactor the code since the `spring-cloud-dependencies` 2022.0.0-M4 does not include the `spring-cloud-netflix-dependencies`
- appconfiguration/azure-spring-cloud-*
   These samples may be included in the second millestone version of Spring Cloud Azure.
-  cosmos/spring-cloud-azure-starter-data-cosmos/*, cosmos/azure-spring-data-cosmos/*, cloudfoundry/azure-cloud-foundry-service-sample
   Spring Data Cosmos samples may be included in the next milestone versions of Spring Cloud Azure.
  No `spring-boot-starter-jersey` dependency is available based on Spring Boot 3.
- keyvault/azure-spring-boot-starter-keyvault-certificates/*
  The samples of `keyvault-certificates-xx` can running with Spring Boot 3, but the JCA samples of `run-with-command-line-xxx` will fail with exception `java.security.NoSuchAlgorithmException: SHA MessageDigest not available`, so these samples should be excluded too.