### PR TITLE
Upgrade for spring-boot 2.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ We use `main` branch as the develop branch while setting the default branch as t
 | spring-cloud-azure_v4.5.0-beta.1 | true           | release branch |
 
 ## Current Branch Supported Versions
-- [spring-boot-dependencies:2.7.3](https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.3/spring-boot-dependencies-2.7.3.pom).
-- [spring-cloud-dependencies:2021.0.3](https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-dependencies/2021.0.3/spring-cloud-dependencies-2021.0.3.pom).
+- [spring-boot-dependencies:2.7.4](https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.4/spring-boot-dependencies-2.7.4.pom).
+- [spring-cloud-dependencies:2021.0.4](https://repo.maven.apache.org/maven2/org/springframework/cloud/spring-cloud-dependencies/2021.0.4/spring-cloud-dependencies-2021.0.4.pom).
 
 ## All Samples in This Repo
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
   </parent>
 
   <groupId>com.azure.spring</groupId>


### PR DESCRIPTION
1. Upgrade spring-boot-starter-parent from 2.7.3 to 2.7.4
2. Update spring-boot-dependencies from 2.7.3 to 2.7.4
3. Update spring-cloud-dependencies from 2021.0.3 to 2021.0.4