### PR TITLE
Add sparse checkout sdk/jdbc for ci github workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           git remote add origin https://github.com/Azure/azure-sdk-for-java.git
           git config core.sparsecheckout true
           echo "sdk/spring" >> .git/info/sparse-checkout
+          echo "sdk/jdbc"   >> .git/info/sparse-checkout
           echo "sdk/spring-experimental" >> .git/info/sparse-checkout
           echo "eng" >> .git/info/sparse-checkout
           echo "sdk/boms" >> .git/info/sparse-checkout


### PR DESCRIPTION
As title.

## Context
This PR: [Merge branch feature/spring-cloud-azure-passwordless-connection to main branch](https://github.com/Azure/azure-sdk-for-java/pull/31373) changed the behaviors of sdk/spring/pom.xml, so we need to update ci.yml here.