### PR TITLE
Delete "client library for java" suffix in all readme.md

### DIFF
--- a/aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-resource-server/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-resource-server/README.md
@@ -1,4 +1,4 @@
-# Sample for Azure AD B2C Resource server Spring Boot client library for Java
+# Sample for Azure AD B2C Resource server Spring Boot
 
 ## Key concepts
 This sample illustrates how to use `spring-cloud-azure-starter-active-directory-b2c` package to work in a resource server and validate tokens. 

--- a/aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-web-application/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory-b2c/aad-b2c-web-application/README.md
@@ -1,4 +1,4 @@
-# Sample for Azure AD B2C Spring Boot client library for Java
+# Sample for Azure AD B2C Spring Boot
 
 ## Key concepts
 This sample illustrates how to use `spring-cloud-azure-starter-active-directory-b2c` package to work with OAuth 2.0 and OpenID Connect protocols with Azure Active Diretory B2C.

--- a/aad/spring-cloud-azure-starter-active-directory/aad-resource-server-by-filter-stateless/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory/aad-resource-server-by-filter-stateless/README.md
@@ -1,4 +1,4 @@
-# Stateless authentication filter sample for Azure AD Spring Boot Starter client library for Java
+# Stateless authentication filter sample for Azure AD Spring Boot Starter
 
 ## Key concepts
 

--- a/aad/spring-cloud-azure-starter-active-directory/aad-resource-server-by-filter/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory/aad-resource-server-by-filter/README.md
@@ -6,7 +6,7 @@ languages:
 products:
 - azure-active-directory
 ---
-# Authentication filter sample for Azure AD Spring Boot Starter client library for Java
+# Authentication filter sample for Azure AD Spring Boot Starter
 
 ## Key concepts
 This sample illustrates how to use `spring-cloud-azure-starter-active-directory` package to plugin JWT token filter into Spring Security filter chain. The filter injects `UserPrincipal` object that is associated with the thread of the current user request. User's AAD membership info, along with token claimsset, JWS object etc. are accessible from the object which can be used for role based authorization. Methods like `isMemberOf` is also supported.

--- a/aad/spring-cloud-azure-starter-active-directory/aad-web-application-and-resource-server/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory/aad-web-application-and-resource-server/README.md
@@ -1,4 +1,4 @@
-# OAuth 2.0 Sample for Azure AD Spring Boot Starter client library for Java
+# OAuth 2.0 Sample for Azure AD Spring Boot Starter
 
 ## Key concepts
 

--- a/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-resource-server-obo/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-resource-server-obo/README.md
@@ -1,4 +1,4 @@
-# Azure OAuth 2.0 Sample for Azure AD Spring Boot Starter Resource Server Obo client library for Java
+# Azure OAuth 2.0 Sample for Azure AD Spring Boot Starter Resource Server Obo
 
 ## Key concepts
 [Resource server access other resources usage] is an extension scenario of the *aad-resource-server* sample. Similarly, this sample illustrates how to protect a Java web API by restricting access to its resources to authorized accounts, and the restricted resource will access other restricted resource, such as Graph API and Custom API.

--- a/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-resource-server/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-resource-server/README.md
@@ -1,4 +1,4 @@
-# Azure OAuth 2.0 Sample for Azure AD Spring Boot Starter Resource Server client library for Java
+# Azure OAuth 2.0 Sample for Azure AD Spring Boot Starter Resource Server
 
 ## Key concepts
 This sample illustrates how to protect a Java web API by restricting access to its resources to authorized accounts only.

--- a/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-web-application/README.md
+++ b/aad/spring-cloud-azure-starter-active-directory/web-client-access-resource-server/aad-web-application/README.md
@@ -1,4 +1,4 @@
-# OAuth 2.0 Sample for Azure AD Spring Boot Starter client library for Java
+# OAuth 2.0 Sample for Azure AD Spring Boot Starter
 
 ## Key concepts
 This sample illustrates how to use `spring-cloud-azure-starter-active-directory` package to work with OAuth 2.0 and OpenID Connect protocols on Azure. This sample will use Microsoft Graph API to retrieve user information.

--- a/appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-initial/README.md
+++ b/appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-convert-sample/azure-spring-cloud-appconfiguration-config-convert-sample-initial/README.md
@@ -1,4 +1,4 @@
-# Spring Cloud Azure Config Conversion Sample client library for Java
+# Spring Cloud Azure Config Conversion Sample
 
 This sample shows how to convert a Spring Cloud Application with Cosmos DB to be using App Configuration + Key Vault
 

--- a/appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-sample/README.md
+++ b/appconfiguration/azure-spring-cloud-appconfiguration-config/azure-spring-cloud-appconfiguration-config-sample/README.md
@@ -1,4 +1,4 @@
-# Spring Cloud Azure Config Sample client library for Java
+# Spring Cloud Azure Config Sample
 
 This sample describes how to use [azure-spring-cloud-starter-appconfiguration-config](https://github.com/Azure/azure-sdk-for-java/tree/azure-spring-cloud-starter-appconfiguration-config_2.8.0/sdk/appconfiguration/azure-spring-cloud-starter-appconfiguration-config) to load configuration properties from App Configuration Service to Spring Environment.
 

--- a/cloudfoundry/azure-cloud-foundry-service-sample/README.md
+++ b/cloudfoundry/azure-cloud-foundry-service-sample/README.md
@@ -1,4 +1,4 @@
-# Cloud Foundry Sample for Azure Spring Boot client library for Java
+# Cloud Foundry Sample for Azure Spring Boot
 ## Key concepts
 This sample project demonstrates how to consume azure services exposed through the Microsoft Azure Service Broker for
 applications running in Cloud Foundry or by consuming the service configuration through a user provided service.

--- a/keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side/README.md
+++ b/keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-client-side/README.md
@@ -1,4 +1,4 @@
-# Azure Spring Boot Key Vault Certificates client library for Java
+# Azure Spring Boot Key Vault Certificates
 
 ## Key concepts
 This sample illustrates how to use [Azure Spring Boot Starter Key Vault Certificates ][azure_spring_boot_starter_key_vault_certificates].

--- a/keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side/README.md
+++ b/keyvault/azure-spring-boot-starter-keyvault-certificates/keyvault-certificates-server-side/README.md
@@ -1,4 +1,4 @@
-# Azure Spring Boot Key Vault Certificates client library for Java
+# Azure Spring Boot Key Vault Certificates
 
 ## Key concepts
 This sample illustrates how to use [Azure Spring Boot Starter Key Vault Certificates ][azure_spring_boot_starter_key_vault_certificates].

--- a/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue/README.md
+++ b/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue/README.md
@@ -1,4 +1,4 @@
-# Sample for Spring JMS with Azure Service Bus Queue Spring Cloud client library for Java 
+# Sample for Spring JMS with Azure Service Bus Queue Spring Cloud
 
 This sample project demonstrates how to use Spring JMS for Azure Service Bus Queue via Spring Boot Starter `spring-cloud-azure-starter-servicebus-jms`.
 

--- a/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-topic/README.md
+++ b/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-topic/README.md
@@ -1,4 +1,4 @@
-# Sample for Spring JMS with Azure Service Bus Topic Spring Cloud client library for Java 
+# Sample for Spring JMS with Azure Service Bus Topic Spring Cloud
 
 This sample project demonstrates how to use Spring JMS Topic for Azure Service Bus via Spring Boot Starter `spring-cloud-azure-starter-servicebus-jms`.
 


### PR DESCRIPTION
Delete "client library for java" suffix in all readme.md.
The suffix is required because the CI check in azure-sdk-for-java repo.
Now such kind of check does not exist anymore. So, it can be deleted.