### PR TITLE
remove idle-timeout in application.properties

### DIFF
--- a/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue/src/main/resources/application.yaml
+++ b/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-queue/src/main/resources/application.yaml
@@ -2,5 +2,4 @@ spring:
   jms:
     servicebus:
       connection-string: ${SERVICEBUS_NAMESPACE_CONNECTION_STRING}
-      idle-timeout: 1800000
       pricing-tier: ${PRICING_TIER}

--- a/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-topic/src/main/resources/application.yaml
+++ b/servicebus/spring-cloud-azure-starter-servicebus-jms/servicebus-jms-topic/src/main/resources/application.yaml
@@ -2,6 +2,5 @@ spring:
   jms:
     servicebus:
       connection-string: ${SERVICEBUS_NAMESPACE_CONNECTION_STRING}
-      idle-timeout: 1800000
       pricing-tier: ${PRICING_TIER}
       topic-client-id: topic-client-id


### PR DESCRIPTION
Remove property of `spring.jms.servicebus.idle-timeout` in the application.properties since this property has the default value and no need to give another try of configuration in the sample.