### PR TITLE
Add "repackage" goal to create fat jar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # https://github.blog/2017-07-06-introducing-code-owners/
 # https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*                                               @saragluna @rujche
-/appconfiguration/                              @saragluna @rujche @mrm9084
+*                                               @Azure-Samples/spring-cloud-azure-maintain
+/appconfiguration/                              @mrm9084 @Azure-Samples/spring-cloud-azure-maintain

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # https://github.blog/2017-07-06-introducing-code-owners/
 # https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*                                               @Azure-Samples/spring-cloud-azure-maintain
-/appconfiguration/                              @mrm9084 @Azure-Samples/spring-cloud-azure-maintain
+*                                               @saragluna @rujche
+/appconfiguration/                              @saragluna @rujche @mrm9084

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,13 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <version>${version.spring.boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Purpose
To fix this problem:

```shell
$ java \
--module-path ./azure-security-keyvault-jca-2.8.2.jar \
--add-modules com.azure.security.keyvault.jca \
-Dsecurity.overridePropertiesFile=true \
-Djava.security.properties==./java.security \
-Dazure.keyvault.uri=xxx \
-Dazure.keyvault.tenant-id=xxx \
-Dazure.keyvault.client-id=xxx \
-Dazure.keyvault.client-secret=xxx \
-jar run-with-command-line-server-side-1.0.0.jar \
--server.port=8443 \
--server.ssl.enabled=true \
--server.ssl.key-alias=pfxchain \
--server.ssl.keystore-type=DKS \
--server.ssl.keyStoreProvider=AzureKeyVault \
--server.ssl.key-store=classpath:keyvault.dummy
no main manifest attribute, in run-with-command-line-server-side-1.0.0.jar
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Just run the steps in https://github.com/Azure-Samples/azure-spring-boot-samples/blob/main/keyvault/azure-securtiy-keyvault-jca/run-with-command-line-server-side/README.md


## What to Check
Verify that there is no error like `no main manifest attribute, in run-with-command-line-server-side-1.0.0.jar`.

## Other Information
<!-- Add any other helpful information that may be needed here. -->