### PR TITLE
Enable Dependabot updates for the spring-boot-3.x branch and for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,23 @@ updates:
       - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
         versions: ["[2025.1.0,)"]
 
+  # Workflow actions are identical on both branches and are not tied to a Spring line,
+  # so both entries are unconstrained. Grouped to keep it to one pull request per branch.
+  - package-ecosystem: "github-actions"
+    directory: "/" # Dependabot scans `.github/workflows` from the repository root
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "spring-boot-3.x"
+    groups:
+      github-actions:
+        patterns: ["*"]
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,25 @@
 
 version: 2
 updates:
+  # Samples on `main` track the latest Spring Cloud Azure 7.x / Spring Boot 4.x.
   - package-ecosystem: "maven" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    target-branch: "main"  
+    target-branch: "main"
+
+  # Samples on `spring-boot-3.x` are pinned to Spring Cloud Azure 6.x / Spring Boot 3.x,
+  # so every dependency that already has a 7.x / 4.x line must be capped here.
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "spring-boot-3.x"
+    ignore:
+      - dependency-name: "com.azure.spring:spring-cloud-azure-dependencies"
+        versions: ["[7.0.0,)"]
+      - dependency-name: "org.springframework.boot:*"
+        versions: ["[4.0.0,)"]
+      - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
+        versions: ["[2025.1.0,)"]
+


### PR DESCRIPTION
## Purpose

Close two gaps in `.github/dependabot.yml`: the `spring-boot-3.x` branch is not covered at all, and the GitHub Actions ecosystem is not covered at all.

### 1. `spring-boot-3.x` receives no version updates

Two constraints combine to leave that branch uncovered today:

1. Dependabot only reads `.github/dependabot.yml` from the repository's **default branch** (`main`). The copy that exists on `spring-boot-3.x` is never evaluated.
2. The single `updates` entry sets `target-branch: "main"`. Per the docs, once `target-branch` is set, only manifests on that branch are checked and all pull requests are opened against it.

As a result every Spring Cloud Azure bump on `spring-boot-3.x` has been raised by hand (#799, #834), while `main` gets them automatically (#832 updated 77 poms in one pull request).

This adds a second `maven` entry targeting `spring-boot-3.x`. Same `package-ecosystem` + `directory` with a different `target-branch` is a supported combination.

The `ignore` rules are required: `spring-boot-3.x` is pinned to the Spring Cloud Azure 6.x / Spring Boot 3.x lines, so without caps Dependabot would immediately propose 7.4.0 / Spring Boot 4.0.x / Spring Cloud 2025.1.x there. Caps are derived from what the branch actually declares:

| Dependency | Current on `spring-boot-3.x` | Ignored |
| --- | --- | --- |
| `com.azure.spring:spring-cloud-azure-dependencies` | 6.4.0 | `[7.0.0,)` |
| `org.springframework.boot:*` | `spring-boot-starter-parent` 3.5.5 (70 poms) | `[4.0.0,)` |
| `org.springframework.cloud:spring-cloud-dependencies` | 2025.0.0 | `[2025.1.0,)` |

Every other external dependency on that branch is managed through a BOM, so no further caps are needed.

### 2. GitHub Actions versions are never updated

The configuration only declared the `maven` ecosystem, so the action versions pinned in `.github/workflows` have never been bumped. Both branches carry the same set:

| Workflow | Action | Pinned | Latest |
| --- | --- | --- | --- |
| `ci.yml` | `actions/checkout` | `v3` | `v7.0.1` |
| `ci.yml` | `actions/setup-java` | `v3` | `v5.7.0` |
| `codeql-analysis.yml` | `actions/checkout` | `v2` | `v7.0.1` |
| `codeql-analysis.yml` | `actions/setup-java` | `v4` | `v5.7.0` |
| `codeql-analysis.yml` | `snow-actions/sparse-checkout` | `v1.1.0` | `v1.2.0` |
| `markdown-link-check.yml` | `actions/checkout` | `@master` | — |
| `markdown-link-check.yml` | `umbrelladocs/action-linkspector` | `v1.1.3` | `v1.5.5` |
| `sync-label-from-azsdk-repo.yml` | `EndBug/label-sync` | `v2.1.0` | `v2.3.3` |

`actions/checkout@v2` and `@v3` are already deprecated and will eventually stop running.

The workflows are identical on both branches and are not tied to a Spring line, so neither `github-actions` entry needs `ignore` rules. Updates are grouped so each branch gets a single pull request rather than one per action. Note that `actions/checkout@master` in `markdown-link-check.yml` is a floating ref and cannot be managed by Dependabot; pinning it to a tag would be a separate change.

## Does this introduce a breaking change?
```
[ ] Yes
[x] No
```

## Pull Request Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[x] Other... Please describe: CI / Dependabot configuration
```

## How to Test

No build impact — this only changes Dependabot configuration.

## What to Check

* `.github/dependabot.yml` parses as valid YAML and contains four `updates` entries: `maven`/`main`, `maven`/`spring-boot-3.x`, `github-actions`/`main`, `github-actions`/`spring-boot-3.x`.
* After merge, Dependabot should open version-update pull requests against `spring-boot-3.x`, and none of them should propose Spring Cloud Azure 7.x, Spring Boot 4.x or Spring Cloud 2025.1.x.
* One grouped GitHub Actions pull request per branch.

## Other Information

Known limitation: entries that use `target-branch` do not apply to Dependabot **security** updates — those always target the default branch. Security fixes for `spring-boot-3.x` still need to be handled manually.

The `.github/dependabot.yml` that lives on `spring-boot-3.x` is inert but currently says `target-branch: "main"`, which is misleading. Deleting it on that branch would be a reasonable follow-up.
